### PR TITLE
Increase length of stoch_restfile

### DIFF
--- a/stochy_data_mod.F90
+++ b/stochy_data_mod.F90
@@ -44,7 +44,7 @@ module stochy_data_mod
  real(kind=kind_phys),public, allocatable :: skebu_save(:,:,:),skebv_save(:,:,:)
  integer,public :: INTTYP
  type(stochy_internal_state),public :: gis_stochy,gis_stochy_ocn,gis_stochy_ocn_skeb
- character(len=128) :: stoch_restfile = './INPUT/ocn_stoch.res.nc'
+ character(len=2048) :: stoch_restfile = './INPUT/ocn_stoch.res.nc' ! same length as restartfiles in mom_cap.F90
 
  contains
 !>@brief The subroutine 'init_stochdata' determins which stochastic physics
@@ -547,7 +547,7 @@ module stochy_data_mod
          print*,'opening stoch_ini'
          ierr=nf90_open(TRIM(stoch_restfile),nf90_nowrite,ncid=stochlun)
          if (ierr .NE. 0) then
-            write(0,*) 'error opening stoch_ini'
+            write(0,*) 'error opening stoch_ini file:', trim(stoch_restfile)
             iret = ierr
             return
          end if


### PR DESCRIPTION
Also print out `stoch_restfile` if the netcdf file open fails

Notes:
1. I extended the length of `stoch_restfile` to 2048, because that is the length of `restartfiles` in MOM6 (and we use `restartfiles` to construct `stoch_restfile`)
1. With this update, `ERS.ne30pg3_t232.1850_CAM60_CLM50%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_SWAV.derecho_intel` test passes; it had been failing because `ERS.ne30pg3_t232.1850_CAM60_CLM50%BGC-CROP_CICE_MOM6_MOSART_DGLC%NOEVOLVE_SWAV.derecho_intel.20251118_132244_dp5juo.mom6.r_stoch.0001-01-07-00000.nc` was too long to fit in the string